### PR TITLE
Bump django version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description=open('README.rst').read(),
     url='https://github.com/vndly-oss/django-closuretree',
     install_requires=[
-        'django >= 2.0, < 2.1',
+        'django >= 2.0, < 2.3',
     ],
     tests_require=['django-setuptest >= 0.2'],
     test_suite='setuptest.setuptest.SetupTestSuite',


### PR DESCRIPTION
```
[django-closuretree] (master ±) django-closuretree ツ pip freeze | rg Django
Django==2.2.12
[django-closuretree] (master ±) django-closuretree ツ python setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing django_closuretree.egg-info/PKG-INFO
writing dependency_links to django_closuretree.egg-info/dependency_links.txt
writing requirements to django_closuretree.egg-info/requires.txt
writing top-level names to django_closuretree.egg-info/top_level.txt
reading manifest file 'django_closuretree.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'django_closuretree.egg-info/SOURCES.txt'
running build_ext
/Users/rtorres/vndly/django-closuretree/.eggs/pep8-1.7.1-py3.7.egg/pep8.py:110: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
Creating test database for alias 'default'...
test_closure_table_of_concrete_model (closuretree.tests.AbstractModelTestCase)
Test the closure table of the concrete model operates correctly. ... ok
test_ancestors (closuretree.tests.AncestorTestCase)
Testing the ancestors method. ... ok
test_children (closuretree.tests.AncestorTestCase)
Testing the children method. ... ok
test_descendants (closuretree.tests.AncestorTestCase)
Testing the descendants method. ... ok
test_adding (closuretree.tests.BaseTestCase) ... ok
test_deletion (closuretree.tests.BaseTestCase) ... ok
test_unicode (closuretree.tests.BaseTestCase)
Test unicoding of the closures works. ... ok
test_creating_with_parent (closuretree.tests.InitialClosureTestCase)
Make sure closures are created when making objects. ... ok
test_ancestor_of (closuretree.tests.IsTestCase)
Test is_ancestor_of method. ... ok
test_child_node (closuretree.tests.IsTestCase)
Test is_child_node method ... ok
test_descendant_of (closuretree.tests.IsTestCase)
Test id_descendant_of method. ... ok
test_get_root (closuretree.tests.IsTestCase)
Test get_root method ... ok
test_basic (closuretree.tests.NoMetaTestCase) ... ok
test_prepopulate (closuretree.tests.PrepopulateTestCase)
Test prepopulating ... ok
test_prepopulate_not_root (closuretree.tests.PrepopulateTestCase)
Test prepopulating when we're not the root ... ok
test_rebuild_from_empty (closuretree.tests.RebuildTestCase)
Test a rebuild when the tree is empty. ... ok
test_rebuild_from_full (closuretree.tests.RebuildTestCase)
Test a rebuild when the tree is correct. ... ok
test_rebuild_from_partial (closuretree.tests.RebuildTestCase)
Test a rebuild when the tree is partially empty. ... ok
test_closure_creation (closuretree.tests.SentinelAttributeTestCase)
Test creation of closures in the sentinel case ... ok
test_num_queries (closuretree.tests.SentinelAttributeTestCase)
Test that we don't need to access the objects until we make a change. ... ok
test_adding (closuretree.tests.UUIDTestCase) ... ok
test_deletion (closuretree.tests.UUIDTestCase) ... ok
test_unicode (closuretree.tests.UUIDTestCase)
Test unicoding of the closures works. ... ok
Destroying test database for alias 'default'...

Coverage Report:
Name                      Stmts   Miss  Cover
---------------------------------------------
closuretree/__init__.py       0      0   100%
closuretree/models.py       142      0   100%
---------------------------------------------
TOTAL                       142      0   100%

PEP8 Report:
closuretree/models.py:36:1: E302 expected 2 blank lines, found 1
closuretree/models.py:42:1: E302 expected 2 blank lines, found 1
closuretree/models.py:68:1: E302 expected 2 blank lines, found 1
closuretree/models.py:72:5: E265 block comment should start with '# '
closuretree/models.py:85:1: E302 expected 2 blank lines, found 1
closuretree/models.py:101:80: E501 line too long (88 > 79 characters)
closuretree/models.py:103:80: E501 line too long (157 > 79 characters)
closuretree/models.py:104:80: E501 line too long (105 > 79 characters)
closuretree/models.py:114:80: E501 line too long (88 > 79 characters)
closuretree/models.py:219:58: E231 missing whitespace after ':'
closuretree/models.py:229:58: E231 missing whitespace after ':'
closuretree/models.py:239:80: E501 line too long (85 > 79 characters)
closuretree/models.py:300:28: E231 missing whitespace after ','
closuretree/models.py:320:13: E265 block comment should start with '# '
closuretree/models.py:322:80: E501 line too long (82 > 79 characters)
closuretree/tests.py:32:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:43:80: E501 line too long (84 > 79 characters)
closuretree/tests.py:53:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:57:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:61:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:65:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:128:80: E501 line too long (92 > 79 characters)
closuretree/tests.py:146:5: E303 too many blank lines (2)
closuretree/tests.py:199:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:237:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:249:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:275:80: E501 line too long (80 > 79 characters)
closuretree/tests.py:302:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:343:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:363:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:374:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:400:80: E501 line too long (83 > 79 characters)
closuretree/tests.py:411:80: E501 line too long (95 > 79 characters)
closuretree/tests.py:426:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:439:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:454:1: E302 expected 2 blank lines, found 1
closuretree/tests.py:458:1: E302 expected 2 blank lines, found 1


----------------------------------------------------------------------
Ran 23 tests in 0.466s

OK```